### PR TITLE
further improve large read performance on Android with even larger internal result chunk size

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # cordova-sqlite-evmax-build-free 0.3.1-dev
 
+- further improve large read performance on Android with even larger internal result chunk size
+
 # cordova-sqlite-evmax-build-free 0.1.2
 
 - patch: improve large read performance on Android with larger internal result chunk size, with Android NDK JAR rebuilt with update from: https://github.com/brody4hire/android-sqlite-evmax-ndk-driver-free/tree/evmax-main-no-icu _which is NOT included in master branch for 0.2.x_

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -408,7 +408,7 @@ public class SQLitePlugin extends CordovaPlugin {
         void open(File dbFile) throws Exception {
             if (!isNativeLibLoaded) {
                 System.loadLibrary("sqlc-evmax-ndk-driver");
-                EVNDKDriver.sqlc_evmax_set_result_chunk_cutoff_size(500 * 1000); // [evmax build] internal cutoff adjusted for large result performance
+                EVNDKDriver.sqlc_evmax_set_result_chunk_cutoff_size(50 * 1000 * 1000); // [evmax build] internal cutoff adjusted for large result performance
                 isNativeLibLoaded = true;
             }
 


### PR DESCRIPTION
to test with this update:

```sh
cordova plugin add https://github.com/storesafe/cordova-sqlite-evmax-build-free#brody-further-read-perf-update
```

From testing on my emulator I think this update should show maybe 50-70% improvement over 0.3.0 as I had published from other PR #14.

I have also tested this with extra-huge read result & do not see any issues with this.

/cc @erkenberg: While this may still not be 100% solution for #12 I am hopeful that this should be good enough to avoid noticeable degradation in realistic large-data cases for the near future, at least.

P.S. I have tested this update with extra-huge read results on some older-looking Android 12 & 13 devices on Browser Stack & did not see any issues.

---

Now published in `0.4.0`