### PR TITLE
DRAFT: [0.1.x patch] patch: further improve large read performance on Android with larger internal result chunk size - DO NOT MERGE

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,6 +2,8 @@
 
 # cordova-sqlite-evmax-build-free patch 0.1.3
 
+- patch: further improve large read performance on Android with even larger internal result chunk size
+
 # cordova-sqlite-evmax-build-free patch 0.1.2
 
 - patch: improve large read performance on Android with larger internal result chunk size, with Android NDK JAR rebuilt with update from: https://github.com/brody4hire/android-sqlite-evmax-ndk-driver-free/tree/evmax-main-no-icu

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changes
 
+# cordova-sqlite-evmax-build-free patch 0.1.3
+
 # cordova-sqlite-evmax-build-free patch 0.1.2
 
 - patch: improve large read performance on Android with larger internal result chunk size, with Android NDK JAR rebuilt with update from: https://github.com/brody4hire/android-sqlite-evmax-ndk-driver-free/tree/evmax-main-no-icu

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-sqlite-evmax-build-free",
-  "version": "0.1.2",
+  "version": "0.1.3-dev",
   "description": "Cordova/PhoneGap sqlite storage - free evmax enterprise version with premium stability and performance improvements including workaround for super-large INSERT transactions & SELECT results on Android (version with external sqlite3 dependencies)",
   "cordova": {
     "id": "cordova-sqlite-evmax-build-free",

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 <plugin xmlns="http://www.phonegap.com/ns/plugins/1.0"
     xmlns:android="http://schemas.android.com/apk/res/android"
     id="cordova-sqlite-evmax-build-free"
-    version="0.1.2">
+    version="0.1.3-dev">
 
     <name>Cordova sqlite storage - free evmax common version branch with premium stability performance improvements including workaround for super-large INSERT transactions and SELECT results on Android (with external sqlite3 dependencies)</name>
 

--- a/src/android/io/sqlc/SQLitePlugin.java
+++ b/src/android/io/sqlc/SQLitePlugin.java
@@ -408,7 +408,7 @@ public class SQLitePlugin extends CordovaPlugin {
         void open(File dbFile) throws Exception {
             if (!isNativeLibLoaded) {
                 System.loadLibrary("sqlc-evmax-ndk-driver");
-                EVNDKDriver.sqlc_evmax_set_result_chunk_cutoff_size(500 * 1000); // [evmax build - patch 0.1.x] internal cutoff adjusted for large result performance
+                EVNDKDriver.sqlc_evmax_set_result_chunk_cutoff_size(50 * 1000 * 1000); // [evmax build - patch 0.1.x] internal cutoff adjusted for large result performance
                 isNativeLibLoaded = true;
             }
 


### PR DESCRIPTION
backporting of update from PR #15 patch-0.1.x - SEE STATUS BELOW:

KNOWN TO CAUSE CRASH with large data test on Moto G9 Play when testing on Browser Stack

STATUS: I would still love to find a way to further increase the performance on 0.1.x, for benefit of Android 10 devices as discussed in #13. Maybe increase internal chunk cutoff size to 1 000 000 rather than 50 000 000, for example. I may revisit this if there is sufficient demand.